### PR TITLE
Fix images.linuxcontainers.org remote type

### DIFF
--- a/lxd/map.jinja
+++ b/lxd/map.jinja
@@ -86,11 +86,8 @@
       'verify_cert': False
     },
     'images_linuxcontainers_org': {
-      'type': 'lxd',
-      'remote_addr': 'https://images.linuxcontainers.org',
-      'cert': '~/.config/lxc/client.crt',
-      'key': '~/.config/lxc/client.key',
-      'verify_cert': False
+      'type': 'simplestreams',
+      'server': 'https://images.linuxcontainers.org'
     },
     'ubuntu': {
       'type': 'simplestreams',


### PR DESCRIPTION
`images.linuxcontainers.org` is a simplestreams server, as can be seen
from `~/.config/lxc/config.yml`. This fixes the inability to import images
from the server.